### PR TITLE
Rename StreamSnatcher to StreamSaavy and add MP3 compatibility mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
-# StreamSnatcher 🎧⚡
+# StreamSaavy 🎧⚡
 
-StreamSnatcher is a modern, desktop-friendly front end for `yt-dlp` that focuses on the
+StreamSaavy is a modern, desktop-friendly front end for `yt-dlp` that focuses on the
 most common YouTube workflows:
 
 * Grab a **single song** and transparently encode it to 256 kbps MP3.
 * Pull down a **single video** and transcode it to an H.264 MP4 capped at 1080p HD.
 * Rip **playlist audio** to MP3 at 256 kbps.
 * Download **playlist video** in MP4 format, limited to 1080p.
+* Fall back to a **Compatibility (MP3)** mode that accepts whatever audio is available
+  and re-encodes it to MP3.
 
 All options are configurable from a clean Tkinter interface that walks you through
 choosing a destination folder, selecting download mode, and overriding defaults when
@@ -18,7 +20,7 @@ needed.
 
 ## 🚀 Feature highlights
 
-* 🎛️ Four dedicated workflows (single/playlist × audio/video)
+* 🎛️ Five dedicated workflows (single/playlist × audio/video + compatibility)
 * 🎚️ Sensible defaults with overrides for bitrate and resolution
 * 💾 Directory picker and persistent logging console
 * 🧰 Runs downloads in the background so the UI stays responsive
@@ -46,7 +48,7 @@ Make sure `ffmpeg` is installed and accessible from your terminal.
 Launch the Tkinter interface via the module entry point:
 
 ```bash
-python -m streamsnatcher_app
+python -m streamsaavy_app
 ```
 
 From here you can paste a YouTube URL, choose where to save the output, and press
@@ -64,7 +66,7 @@ development tools as needed and run linting or tests that you add.
 
 ## 📜 License
 
-StreamSnatcher is released under the **MIT License**.
+StreamSaavy is released under the **MIT License**.
 
 ---
 

--- a/streamsaavy_app/__init__.py
+++ b/streamsaavy_app/__init__.py
@@ -1,0 +1,3 @@
+"""StreamSaavy GUI application package."""
+
+__all__ = ["main", "downloader", "ui"]

--- a/streamsaavy_app/__main__.py
+++ b/streamsaavy_app/__main__.py
@@ -1,4 +1,4 @@
-"""Allow running the package with `python -m streamsnatcher_app`."""
+"""Allow running the package with `python -m streamsaavy_app`."""
 from __future__ import annotations
 
 from .main import main

--- a/streamsaavy_app/main.py
+++ b/streamsaavy_app/main.py
@@ -1,4 +1,4 @@
-"""Entry point for launching the StreamSnatcher UI."""
+"""Entry point for launching the StreamSaavy UI."""
 from __future__ import annotations
 
 from .ui import run

--- a/streamsaavy_app/ui.py
+++ b/streamsaavy_app/ui.py
@@ -1,4 +1,4 @@
-"""Tkinter powered graphical interface for StreamSnatcher."""
+"""Tkinter powered graphical interface for StreamSaavy."""
 from __future__ import annotations
 
 import queue
@@ -22,20 +22,25 @@ from tkinter import (
 from tkinter import ttk
 from typing import Dict, Optional
 
-from .downloader import BackgroundDownloader, DownloadMode, DownloadRequest, StreamSnatcherDownloader
+from .downloader import (
+    BackgroundDownloader,
+    DownloadMode,
+    DownloadRequest,
+    StreamSaavyDownloader,
+)
 
 
-class StreamSnatcherApp(Tk):
+class StreamSaavyApp(Tk):
     """Main application window."""
 
     def __init__(self) -> None:
         super().__init__()
-        self.title("StreamSnatcher - yt-dlp Power UI")
+        self.title("StreamSaavy - yt-dlp Power UI")
         self.geometry("960x640")
         self.minsize(800, 600)
 
         self._log_queue: "queue.Queue[str]" = queue.Queue()
-        self._downloader = BackgroundDownloader(StreamSnatcherDownloader(self.queue_log))
+        self._downloader = BackgroundDownloader(StreamSaavyDownloader(self.queue_log))
 
         self.save_path = Path.home()
         self.mode_var = StringVar(value=DownloadMode.SINGLE_SONG.value)
@@ -58,12 +63,12 @@ class StreamSnatcherApp(Tk):
         container = ttk.Frame(self, padding=20)
         container.pack(fill=BOTH, expand=True)
 
-        header = ttk.Label(container, text="StreamSnatcher", font=("Segoe UI", 24, "bold"))
+        header = ttk.Label(container, text="StreamSaavy", font=("Segoe UI", 24, "bold"))
         header.grid(row=0, column=0, columnspan=4, sticky=W)
 
         subtitle = ttk.Label(
             container,
-            text="High-touch yt-dlp front-end for songs, videos, and playlists",
+            text="High-touch yt-dlp front-end with MP3 compatibility fallback",
             font=("Segoe UI", 12),
         )
         subtitle.grid(row=1, column=0, columnspan=4, sticky=W, pady=(0, 20))
@@ -91,6 +96,7 @@ class StreamSnatcherApp(Tk):
                 (DownloadMode.SINGLE_VIDEO, "Single Video"),
                 (DownloadMode.PLAYLIST_SONGS, "Playlist (Audio)"),
                 (DownloadMode.PLAYLIST_VIDEOS, "Playlist (Video)"),
+                (DownloadMode.COMPATIBILITY, "Compatibility (MP3)"),
             ]
         ):
             ttk.Radiobutton(
@@ -262,5 +268,5 @@ class StreamSnatcherApp(Tk):
         self.log_text.configure(state=DISABLED)
 
 def run() -> None:
-    app = StreamSnatcherApp()
+    app = StreamSaavyApp()
     app.mainloop()

--- a/streamsnatcher_app/__init__.py
+++ b/streamsnatcher_app/__init__.py
@@ -1,3 +1,0 @@
-"""StreamSnatcher GUI application package."""
-
-__all__ = ["main", "downloader", "ui"]


### PR DESCRIPTION
## Summary
- rename the application package and interface branding to StreamSaavy
- add an MP3 compatibility download mode that accepts any available audio stream
- refresh the documentation to reflect the new name and workflow options

## Testing
- python -m compileall streamsaavy_app

------
https://chatgpt.com/codex/tasks/task_e_68e4b17a7644832c9b560c864d9ae1b6