### PR TITLE
Add download progress bar and cookie import to GUI

### DIFF
--- a/download.py
+++ b/download.py
@@ -41,12 +41,15 @@ def get_user_input():
     
     return choice, url, destination
 
-def create_command(choice, url, destination):
+def create_command(choice, url, destination, cookies_path: Optional[str] = None):
     base_command = ["yt-dlp", "--progress", "--newline"]
 
-    cookies_file = Path.home() / ".yt-dlp-cookies.txt"
-    if cookies_file.exists():
-        base_command.extend(["--cookies-from-browser", "Chrome"])
+    if cookies_path:
+        base_command.extend(["--cookies", cookies_path])
+    else:
+        cookies_file = Path.home() / ".yt-dlp-cookies.txt"
+        if cookies_file.exists():
+            base_command.extend(["--cookies-from-browser", "Chrome"])
     
     base_command.extend([
         "-P", destination,
@@ -114,6 +117,9 @@ def monitor_progress(
 
         time.sleep(0.1)
 
+    if progress_handler is not None:
+        progress_handler(100.0)
+
     completion_message = "\nDownload completed successfully!"
     if log_handler is not None:
         log_handler(completion_message.strip())
@@ -128,6 +134,7 @@ def run_download(
     *,
     log_handler: Optional[LineHandler] = None,
     progress_handler: Optional[ProgressHandler] = None,
+    cookies_path: Optional[str] = None,
 ) -> None:
     """Execute a yt-dlp download using the CLI options.
 
@@ -145,7 +152,7 @@ def run_download(
         Optional callback receiving progress percentage updates.
     """
 
-    command = create_command(choice, url, destination)
+    command = create_command(choice, url, destination, cookies_path=cookies_path)
 
     if log_handler is not None:
         log_handler("Starting download...")
@@ -182,10 +189,18 @@ def download_video(
     *,
     log_handler: Optional[LineHandler] = None,
     progress_handler: Optional[ProgressHandler] = None,
+    cookies_path: Optional[str] = None,
 ) -> None:
     """Convenience wrapper for single video downloads used by the GUI."""
 
-    run_download("1", url, output_dir, log_handler=log_handler, progress_handler=progress_handler)
+    run_download(
+        "1",
+        url,
+        output_dir,
+        log_handler=log_handler,
+        progress_handler=progress_handler,
+        cookies_path=cookies_path,
+    )
 
 def main():
     try:

--- a/streamsaavy_app/ui.py
+++ b/streamsaavy_app/ui.py
@@ -14,6 +14,7 @@ from tkinter import (
     S,
     W,
     BooleanVar,
+    DoubleVar,
     StringVar,
     Text,
     Tk,
@@ -47,6 +48,8 @@ class StreamSaavyApp(Tk):
         self.video_resolution_var = StringVar(value="1080")
         self.embed_thumbnail_var = BooleanVar(value=True)
         self.embed_metadata_var = BooleanVar(value=True)
+        self.progress_var = DoubleVar(value=0.0)
+        self.cookies_path: Optional[Path] = None
 
         self._audio_widgets = []
         self._video_widgets = []
@@ -74,19 +77,24 @@ class StreamSaavyApp(Tk):
         # URL entry
         ttk.Label(container, text="Source URL:").grid(row=2, column=0, sticky=W)
         self.url_entry = ttk.Entry(container, textvariable=self.url_var, width=70)
-        self.url_entry.grid(row=2, column=1, columnspan=3, sticky=W + E, pady=5)
+        self.url_entry.grid(row=2, column=1, columnspan=2, sticky=W + E, pady=5)
+        cookies_button = ttk.Button(container, text="Import Cookies", command=self.import_cookies)
+        cookies_button.grid(row=2, column=3, sticky=E, padx=(8, 0))
         self.url_entry.focus_set()
 
+        self.cookies_status = ttk.Label(container, text="🍪 No cookies loaded", font=("Segoe UI", 9))
+        self.cookies_status.grid(row=3, column=1, columnspan=3, sticky=W)
+
         # Save location
-        ttk.Label(container, text="Save to:").grid(row=3, column=0, sticky=W)
+        ttk.Label(container, text="Save to:").grid(row=4, column=0, sticky=W)
         self.save_label = ttk.Label(container, text=str(self.save_path), relief="groove", padding=(6, 3))
-        self.save_label.grid(row=3, column=1, columnspan=2, sticky=W + E, pady=5)
+        self.save_label.grid(row=4, column=1, columnspan=2, sticky=W + E, pady=5)
         choose_button = ttk.Button(container, text="Choose...", command=self.choose_save_location)
-        choose_button.grid(row=3, column=3, sticky=E)
+        choose_button.grid(row=4, column=3, sticky=E)
 
         # Mode selection
         mode_frame = ttk.LabelFrame(container, text="What are we grabbing?", padding=10)
-        mode_frame.grid(row=4, column=0, columnspan=4, sticky=W + E, pady=10)
+        mode_frame.grid(row=5, column=0, columnspan=4, sticky=W + E, pady=10)
 
         for index, (mode, label) in enumerate(
             [
@@ -107,7 +115,7 @@ class StreamSaavyApp(Tk):
 
         # Audio options
         audio_frame = ttk.LabelFrame(container, text="Audio settings", padding=10)
-        audio_frame.grid(row=5, column=0, columnspan=2, sticky=W + E)
+        audio_frame.grid(row=6, column=0, columnspan=2, sticky=W + E)
         ttk.Label(audio_frame, text="Bitrate (kbps):").grid(row=0, column=0, sticky=W)
         audio_entry = ttk.Entry(audio_frame, textvariable=self.audio_bitrate_var, width=12)
         audio_entry.grid(row=0, column=1, sticky=W)
@@ -121,7 +129,7 @@ class StreamSaavyApp(Tk):
 
         # Video options
         video_frame = ttk.LabelFrame(container, text="Video settings", padding=10)
-        video_frame.grid(row=5, column=2, columnspan=2, sticky=W + E)
+        video_frame.grid(row=6, column=2, columnspan=2, sticky=W + E)
         ttk.Label(video_frame, text="Max resolution (p):").grid(row=0, column=0, sticky=W)
         video_entry = ttk.Entry(video_frame, textvariable=self.video_resolution_var, width=12)
         video_entry.grid(row=0, column=1, sticky=W)
@@ -131,19 +139,19 @@ class StreamSaavyApp(Tk):
             container,
             text="Embed metadata tags",
             variable=self.embed_metadata_var,
-        ).grid(row=6, column=0, columnspan=4, sticky=W, pady=(8, 0))
+        ).grid(row=7, column=0, columnspan=4, sticky=W, pady=(8, 0))
 
         # Buttons
         self.download_button = ttk.Button(container, text="Start download", command=self.start_download)
-        self.download_button.grid(row=7, column=0, pady=12, sticky=W)
+        self.download_button.grid(row=8, column=0, pady=12, sticky=W)
 
         self.cancel_button = ttk.Button(container, text="Cancel", command=self.cancel_download, state=DISABLED)
-        self.cancel_button.grid(row=7, column=1, pady=12, sticky=W)
+        self.cancel_button.grid(row=8, column=1, pady=12, sticky=W)
 
         # Log area
         log_frame = ttk.LabelFrame(container, text="Activity", padding=10)
-        log_frame.grid(row=8, column=0, columnspan=4, sticky=N + S + W + E, pady=(10, 0))
-        container.rowconfigure(8, weight=1)
+        log_frame.grid(row=9, column=0, columnspan=4, sticky=N + S + W + E, pady=(10, 0))
+        container.rowconfigure(9, weight=1)
         container.columnconfigure(1, weight=1)
         container.columnconfigure(2, weight=1)
         container.columnconfigure(3, weight=1)
@@ -151,6 +159,14 @@ class StreamSaavyApp(Tk):
         self.log_text = Text(log_frame, height=14, wrap="word")
         self.log_text.pack(fill=BOTH, expand=True)
         self.log_text.configure(state=DISABLED)
+
+        self.progress_bar = ttk.Progressbar(
+            container,
+            maximum=100,
+            mode="determinate",
+            variable=self.progress_var,
+        )
+        self.progress_bar.grid(row=10, column=0, columnspan=4, sticky=W + E, pady=(10, 0))
 
         self._mode_changed()
 
@@ -186,6 +202,33 @@ class StreamSaavyApp(Tk):
             self.save_label.configure(text=directory)
             self.queue_log(f"Save location set to {directory}")
 
+    def import_cookies(self) -> None:
+        file_path = filedialog.askopenfilename(
+            initialdir=str(self.save_path),
+            title="Select Cookies File",
+            filetypes=[("Text Files", "*.txt"), ("All Files", "*.*")],
+        )
+        if not file_path:
+            return
+
+        candidate = Path(file_path)
+        if not candidate.exists() or not candidate.is_file():
+            messagebox.showerror("Invalid cookies file", "❌ Invalid cookies file or unreadable format")
+            self.queue_log("❌ Invalid cookies file or unreadable format")
+            return
+
+        try:
+            with candidate.open("r", encoding="utf-8", errors="ignore") as handle:
+                handle.read(0)
+        except OSError:
+            messagebox.showerror("Invalid cookies file", "❌ Invalid cookies file or unreadable format")
+            self.queue_log("❌ Invalid cookies file or unreadable format")
+            return
+
+        self.cookies_path = candidate
+        self.cookies_status.configure(text=f"🍪 Cookies loaded: {candidate}")
+        self.queue_log(f"Cookies loaded from {candidate}")
+
     def start_download(self) -> None:
         url = self.url_var.get().strip()
         if not url:
@@ -205,6 +248,12 @@ class StreamSaavyApp(Tk):
             messagebox.showerror("Unsupported mode", f"Mode {mode.value} is not supported by the CLI backend.")
             return
 
+        if self.cookies_path is not None and not self.cookies_path.exists():
+            messagebox.showerror("Cookies missing", "The selected cookies file can no longer be found.")
+            self.cookies_status.configure(text="🍪 No cookies loaded")
+            self.cookies_path = None
+            return
+
         if self._is_downloading:
             messagebox.showwarning("Busy", "A download is already in progress.")
             return
@@ -213,13 +262,14 @@ class StreamSaavyApp(Tk):
         self.download_button.configure(state=DISABLED)
         self.cancel_button.configure(state=NORMAL)
         self.queue_log("Launching download job...")
+        self._update_progress(0.0)
 
         def worker() -> None:
             def log_handler(message: str) -> None:
                 self.queue_log(message)
 
             def progress_handler(percentage: float) -> None:
-                self.queue_log(f"Progress: {percentage:.1f}%")
+                self.after(0, lambda value=percentage: self._update_progress(value))
 
             try:
                 run_download(
@@ -228,6 +278,7 @@ class StreamSaavyApp(Tk):
                     str(self.save_path),
                     log_handler=log_handler,
                     progress_handler=progress_handler,
+                    cookies_path=str(self.cookies_path) if self.cookies_path is not None else None,
                 )
             except Exception as exc:  # pragma: no cover - runtime integration
                 self.queue_log(f"ERROR: {exc}")
@@ -251,8 +302,11 @@ class StreamSaavyApp(Tk):
         self.cancel_button.configure(state=DISABLED)
         if error is not None:
             messagebox.showerror("Download failed", str(error))
+            self._update_progress(0.0)
         else:
             messagebox.showinfo("Download complete", "All tasks finished successfully")
+            self.queue_log("✅ Download complete")
+            self._update_progress(100.0)
             self.queue_log("Download pipeline completed")
 
     # ------------------------------------------------------------------
@@ -276,6 +330,11 @@ class StreamSaavyApp(Tk):
         self.log_text.insert(END, message + "\n")
         self.log_text.see(END)
         self.log_text.configure(state=DISABLED)
+
+    def _update_progress(self, percentage: float) -> None:
+        bounded = max(0.0, min(percentage, 100.0))
+        self.progress_var.set(bounded)
+        self.progress_bar.update_idletasks()
 
 def run() -> None:
     app = StreamSaavyApp()


### PR DESCRIPTION
## Summary
- add a determinate progress bar to the GUI and update it from background download threads
- allow users to import a cookies file and feed it to yt-dlp for authenticated downloads
- extend the backend command builder to accept an optional cookies path and finalize progress updates

## Testing
- python -m compileall streamsaavy_app download.py

------
https://chatgpt.com/codex/tasks/task_e_68e53c1c850c832c9c55d4da0e835050