### PR TITLE
Fix async exception handling in UI downloader

### DIFF
--- a/streamsaavy_app/ui.py
+++ b/streamsaavy_app/ui.py
@@ -221,6 +221,7 @@ class StreamSaavyApp(Tk):
             def progress_handler(percentage: float) -> None:
                 self.queue_log(f"Progress: {percentage:.1f}%")
 
+            error: Optional[Exception] = None
             try:
                 run_download(
                     choice,
@@ -230,10 +231,10 @@ class StreamSaavyApp(Tk):
                     progress_handler=progress_handler,
                 )
             except Exception as exc:  # pragma: no cover - runtime integration
+                error = exc
                 self.queue_log(f"ERROR: {exc}")
-                self.after(0, lambda: self._finish_download(error=exc))
-            else:
-                self.after(0, lambda: self._finish_download(error=None))
+            finally:
+                self.after(0, lambda err=error: self._finish_download(error=err))
 
         self._download_thread = threading.Thread(target=worker, daemon=True)
         self._download_thread.start()


### PR DESCRIPTION
## Summary
- ensure UI worker thread always captures exceptions before scheduling callbacks
- centralize download completion callback to avoid referencing deleted exception variables

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e53d37543c832caf7a49743729a0b7