### PR TITLE
Force yt-dlp to only use direct formats

### DIFF
--- a/download.py
+++ b/download.py
@@ -66,26 +66,49 @@ def create_command(choice, url, destination, cookies_path: Optional[str] = None)
             base_command.extend(["--cookies-from-browser", "Chrome"])
     
     base_command.extend([
-        "-P", destination,
+        "-P",
+        destination,
         "--write-thumbnail",
         "--write-description",
-        "--write-info-json"
+        "--write-info-json",
+        "--compat-options",
+        "no-youtube-channel-redirect,no-youtube-live-check,prefer-free-formats,manifestless",
     ])
+
+    format_selector = "bestaudio[ext=m4a]/bestaudio[ext=webm]/best[protocol*=https]"
 
     if choice == '1':  # Single video
         base_command.extend(["--remux-video", "mp4"])
-        return base_command + ["-f", "bv*[height<=1080][ext=mp4]+ba[ext=m4a]/b[ext=mp4]", "--no-playlist", url]
+        return base_command + ["-f", format_selector, "--no-playlist", url]
 
     elif choice == '2':  # Single song
-        base_command.extend(["-f", "bestaudio", "--extract-audio", "--audio-format", "mp3", "--audio-quality", "0.256", "--no-playlist"])
+        base_command.extend([
+            "-f",
+            format_selector,
+            "--extract-audio",
+            "--audio-format",
+            "mp3",
+            "--audio-quality",
+            "0.256",
+            "--no-playlist",
+        ])
         return base_command + [url]
 
     elif choice == '3':  # Playlist videos
         base_command.extend(["--remux-video", "mp4", "--yes-playlist"])
-        return base_command + ["-f", "bv*[height<=1080][ext=mp4]+ba[ext=m4a]/b[ext=mp4]", url]
+        return base_command + ["-f", format_selector, url]
 
     elif choice == '4':  # Playlist songs
-        base_command.extend(["-f", "bestaudio", "--extract-audio", "--audio-format", "mp3", "--audio-quality", "0.256", "--yes-playlist"])
+        base_command.extend([
+            "-f",
+            format_selector,
+            "--extract-audio",
+            "--audio-format",
+            "mp3",
+            "--audio-quality",
+            "0.256",
+            "--yes-playlist",
+        ])
         return base_command + [url]
     
 def monitor_progress(


### PR DESCRIPTION
## Summary
- update CLI download helper to request only direct HTTPS or non-SABR audio formats and add strict compat options
- align GUI downloader to reuse the same safe format selector and enforce yt-dlp compatibility flags

## Testing
- python -m compileall download.py streamsaavy_app

------
https://chatgpt.com/codex/tasks/task_e_68e543be654c832c9d44011266e612ef