### PR TITLE
Simplify StreamSaavy mode selection to audio or video

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,7 @@ It provides a **clean Tkinter interface** that wraps `yt-dlp`’s power into sim
 
 ## 🚀 Feature Highlights
 
-- 🎛️ **Five core workflows**
-  - Single Song → 256 kbps MP3
-  - Single Video → H.264 MP4 (1080 p)
-  - Playlist Audio → MP3 (256 kbps)
-  - Playlist Video → MP4 (1080 p)
-  - Compatibility Mode → re-encodes anything to MP3 when format data is missing
+- 🎛️ **Two streamlined outputs** – grab either H.264 MP4 video or MP3 audio while supporting single links and playlists alike
 - 🎚️ **Smart defaults** with optional bitrate / resolution overrides
 - 📂 **Destination picker** that remembers your last save folder
 - 💬 **Persistent console** that mirrors `yt-dlp` output in real time
@@ -59,13 +54,13 @@ ffmpeg -version
 python -m streamsaavy_app
 ```
 
-Paste a YouTube URL, select your workflow (audio/video, single/playlist), choose where to save, and click **Start Download**.
+Paste a YouTube or playlist URL, pick between **Video (MP4)** or **Audio (MP3)**, choose where to save, and click **Start Download**.
 A live activity panel displays `yt-dlp` progress, while the main window stays fully interactive.
 
 ### 📱 Terminal-friendly CLI (great for Android/Termux)
 
 ```bash
-python -m streamsaavy_app --ui cli --mode single_song --output /sdcard/Download \
+python -m streamsaavy_app --ui cli --mode audio --output /sdcard/Download \
     "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
 ```
 
@@ -75,13 +70,21 @@ Run `python -m streamsaavy_app.cli --help` to see the full list of flags.
 
 ### 🌐 Web dashboard
 
-```bash
-python -m streamsaavy_app --ui web --host 0.0.0.0 --port 5000
-```
+1. Activate your virtual environment (if you created one during installation).
+2. From the project directory run:
 
-Open `http://127.0.0.1:5000` (or replace the host if you exposed it on your network) to access a sleek
-web interface with live progress, log streaming, and cookie uploads. This is ideal when running inside
-Termux—launch the command above and visit the URL from your Android browser.
+   ```bash
+   python -m streamsaavy_app --ui web --host 0.0.0.0 --port 5000
+   ```
+
+   - Use `--host 127.0.0.1` if you only need to reach the site from the same machine.
+   - Swap the port if `5000` is already taken.
+
+3. Open a browser to `http://127.0.0.1:5000` (or the host/port you specified) to reach the dashboard.
+
+The web UI mirrors the desktop experience: paste a link, decide between MP4 video or MP3 audio, and track
+live logs/progress. Cookie uploads are supported as well, making it perfect for Android/Termux – start the
+server on your device and visit the URL from mobile Chrome or Firefox.
 
 ---
 

--- a/streamsaavy_app/cli.py
+++ b/streamsaavy_app/cli.py
@@ -57,8 +57,8 @@ def run_cli(argv: Optional[Sequence[str]] = None) -> int:
     parser.add_argument(
         "--mode",
         choices=list(_iter_modes()),
-        default=DownloadMode.SINGLE_SONG.value,
-        help="Download workflow to use.",
+        default=DownloadMode.VIDEO.value,
+        help="Choose between mp4 video or mp3 audio exports.",
     )
     parser.add_argument(
         "--output",

--- a/streamsaavy_app/templates/index.html
+++ b/streamsaavy_app/templates/index.html
@@ -98,6 +98,12 @@
         transition: transform 0.15s ease, box-shadow 0.2s ease;
       }
 
+      .actions button.secondary {
+        background: rgba(148, 163, 184, 0.2);
+        color: #e2e8f0;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+      }
+
       .actions button:hover {
         transform: translateY(-1px);
         box-shadow: 0 15px 28px rgba(56, 189, 248, 0.35);
@@ -184,15 +190,6 @@
 
         <div class="row">
           <div>
-            <label for="mode">Workflow</label>
-            <select id="mode" name="mode">
-              {% for value, label in modes %}
-              <option value="{{ value }}">{{ label }}</option>
-              {% endfor %}
-            </select>
-          </div>
-
-          <div>
             <label for="audio_bitrate">Audio bitrate</label>
             <input type="text" id="audio_bitrate" name="audio_bitrate" value="256k" />
           </div>
@@ -218,8 +215,14 @@
         <label for="cookies">Cookies file (optional)</label>
         <input type="file" id="cookies" name="cookies" accept=".txt" />
 
+        <p style="margin-top: 1rem; color: rgba(226, 232, 240, 0.75)">
+          Playlists and individual links are supported for both buttons. Choose whether you want the
+          full MP4 video or an MP3 audio-only export below.
+        </p>
+
         <div class="actions">
-          <button type="submit">Start download</button>
+          <button type="submit" name="mode" value="video">Download Video (MP4)</button>
+          <button type="submit" name="mode" value="audio" class="secondary">Download Audio (MP3)</button>
         </div>
       </form>
 

--- a/streamsaavy_app/ui.py
+++ b/streamsaavy_app/ui.py
@@ -42,7 +42,7 @@ class StreamSaavyApp(Tk):
         self._is_downloading = False
 
         self.save_path = Path.home()
-        self.mode_var = StringVar(value=DownloadMode.SINGLE_SONG.value)
+        self.mode_var = StringVar(value=DownloadMode.VIDEO.value)
         self.url_var = StringVar()
         self.audio_bitrate_var = StringVar(value="256k")
         self.video_resolution_var = StringVar(value="1080")
@@ -69,7 +69,7 @@ class StreamSaavyApp(Tk):
 
         subtitle = ttk.Label(
             container,
-            text="High-touch yt-dlp front-end with MP3 compatibility fallback",
+            text="High-touch yt-dlp front-end for MP4 video and MP3 audio",
             font=("Segoe UI", 12),
         )
         subtitle.grid(row=1, column=0, columnspan=4, sticky=W, pady=(0, 20))
@@ -93,16 +93,13 @@ class StreamSaavyApp(Tk):
         choose_button.grid(row=4, column=3, sticky=E)
 
         # Mode selection
-        mode_frame = ttk.LabelFrame(container, text="What are we grabbing?", padding=10)
+        mode_frame = ttk.LabelFrame(container, text="Choose output format", padding=10)
         mode_frame.grid(row=5, column=0, columnspan=4, sticky=W + E, pady=10)
 
         for index, (mode, label) in enumerate(
             [
-                (DownloadMode.SINGLE_SONG, "Single Song (Audio)"),
-                (DownloadMode.SINGLE_VIDEO, "Single Video"),
-                (DownloadMode.PLAYLIST_SONGS, "Playlist (Audio)"),
-                (DownloadMode.PLAYLIST_VIDEOS, "Playlist (Video)"),
-                (DownloadMode.COMPATIBILITY, "Compatibility (MP3)"),
+                (DownloadMode.VIDEO, "Video (MP4)"),
+                (DownloadMode.AUDIO, "Audio Only (MP3)"),
             ]
         ):
             ttk.Radiobutton(

--- a/streamsaavy_app/web.py
+++ b/streamsaavy_app/web.py
@@ -114,7 +114,7 @@ def _build_request(form: Dict[str, str], cookies_path: Optional[Path]) -> Downlo
         raise ValueError("A video or playlist URL is required.")
 
     save_directory = Path(form.get("save_path") or (Path.home() / "Downloads"))
-    mode = DownloadMode(form.get("mode", DownloadMode.SINGLE_SONG.value))
+    mode = DownloadMode(form.get("mode", DownloadMode.VIDEO.value))
 
     audio_bitrate = form.get("audio_bitrate", "256k")
     video_resolution = form.get("video_resolution", "1080")
@@ -139,7 +139,6 @@ def index() -> str:
     default_save_path = str(Path.home() / "Downloads")
     return render_template(
         "index.html",
-        modes=[(mode.value, mode.name.replace("_", " ").title()) for mode in DownloadMode],
         state=snapshot,
         default_save_path=default_save_path,
     )


### PR DESCRIPTION
## Summary
- collapse the downloader modes down to audio (mp3) and video (mp4) while letting playlists work automatically
- refresh the web and desktop interfaces to offer clear video vs audio controls and tidy status messaging
- update CLI defaults and documentation so the simplified workflows are reflected everywhere

## Testing
- python -m compileall streamsaavy_app

------
https://chatgpt.com/codex/tasks/task_e_68eef75685bc832c9c51b866465e708c